### PR TITLE
Passport auth

### DIFF
--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -1,18 +1,20 @@
 // These helper functions can be called from any page JS. 
 
 // Get the currently-logged-in user info. We return null if no user is logged in.
-
 function getCurrentUser() {
-  var userToken = null;
-  if (localStorage.currentUser) {
-    userToken = JSON.parse(localStorage.getItem('currentUser'));
+  var jwtEncoded = localStorage.getItem('userToken');
+  var userInfo = null;
+  if (jwtEncoded) {
+    userInfo = jwt_decode(jwtEncoded);
+    userInfo['token'] = jwtEncoded;
+    //jwtDecoded = JSON.parse(jwtDecoded);
   }
-  return userToken;
+  return userInfo;
 }
 
 // Log the user out, by deleting the token form local storage
 function logout() {
   if (localStorage.currentUser) {
-    localStorage.removeItem('currentUser');
+    localStorage.removeItem('userToken');
   }
 }

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -29,10 +29,10 @@ $(document).ready(function () {
           // The JWT comes in with a prefix on it: "JWT ". That makes it easier to spot as a JWT.
           // We strip that header so only the token remains.
           var jwtEncoded = result.token.split(" ")[1];
-          var jwtDecoded = jwt_decode(jwtEncoded);
           // Store the user token in local storage
-          localStorage.setItem('currentUser', JSON.stringify(jwtDecoded));
-          console.log("Decoded token contents: " + JSON.stringify(jwtDecoded));
+          localStorage.setItem('userToken', jwtEncoded);
+          var currentUser = getCurrentUser();
+          console.log("Decoded token contents: " + JSON.stringify(currentUser));
         } else {
           console.log("Failed. Response: " + JSON.stringify(result));
         }


### PR DESCRIPTION
Changed login logic to store the encoded token in local storage, so it's available for authenticating API calls, later. Accordingly, updated auth helpers to decode the token on-the-fly, instead of reading decoded token info from local storage.